### PR TITLE
[all] Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.5.0 (2019-07-08)
 
 - **[Breaking change]** Add types to CFG blocks.
 - **[Internal]** Switch to `travis.com` for CI.

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm1-tree"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Abstract Syntax Tree (AST) for AVM1"
 documentation = "https://github.com/open-flash/avm1-tree"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avm1-tree",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "homepage": "https://github.com/open-flash/avm1-tree",
   "description": "Abstract Syntax Tree for AVM1",
   "private": true,


### PR DESCRIPTION
- **[Breaking change]** Add types to CFG blocks.

### Rust

- **[Fix]** Rename `send_vars_method` to `method` in `GetUrl2`.