### PR TITLE
[all] Replace code bytes with code sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- **[Breaking change]** Replace code bytes with code sizes for raw actions defining code blocks (`DefineFunction`, `DefineFunction2`, `Try`, `With`)
+
 # 0.5.0 (2019-07-08)
 
 - **[Breaking change]** Add types to CFG blocks.

--- a/rs/src/actions.rs
+++ b/rs/src/actions.rs
@@ -1,4 +1,4 @@
-use super::helpers::{buffer_to_hex, hex_to_buffer, option_buffer_to_hex, option_hex_to_buffer};
+use super::helpers::{buffer_to_hex, hex_to_buffer};
 use super::value::Value;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -23,8 +23,7 @@ pub struct DefineFunction {
   // Empty string if anonymous
   pub name: String,
   pub parameters: Vec<String>,
-  #[serde(serialize_with = "buffer_to_hex", deserialize_with = "hex_to_buffer")]
-  pub body: Vec<u8>,
+  pub body_size: u16,
 }
 
 pub mod define_function2 {
@@ -53,8 +52,7 @@ pub struct DefineFunction2 {
   pub preload_global: bool,
   pub register_count: usize,
   pub parameters: Vec<define_function2::Parameter>,
-  #[serde(serialize_with = "buffer_to_hex", deserialize_with = "hex_to_buffer")]
-  pub body: Vec<u8>,
+  pub body_size: u16,
 }
 
 // Action code 0x83
@@ -154,21 +152,12 @@ pub mod r#try {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct Try {
-  #[serde(serialize_with = "buffer_to_hex", deserialize_with = "hex_to_buffer")]
-  pub r#try: Vec<u8>,
+  pub try_size: u16,
   pub catch_target: r#try::CatchTarget,
-  #[serde(
-    skip_serializing_if = "Option::is_none",
-    serialize_with = "option_buffer_to_hex",
-    deserialize_with = "option_hex_to_buffer"
-  )]
-  pub catch: Option<Vec<u8>>,
-  #[serde(
-    skip_serializing_if = "Option::is_none",
-    serialize_with = "option_buffer_to_hex",
-    deserialize_with = "option_hex_to_buffer"
-  )]
-  pub finally: Option<Vec<u8>>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub catch_size: Option<u16>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub finally_size: Option<u16>,
 }
 
 // Action code 0x8a
@@ -177,7 +166,6 @@ pub struct Try {
 pub struct WaitForFrame {
   pub frame: usize,
   pub skip_count: usize,
-  // TODO: body: Vec<Action> ?
 }
 
 // Action code 0x8d
@@ -185,7 +173,6 @@ pub struct WaitForFrame {
 #[serde(rename_all = "snake_case")]
 pub struct WaitForFrame2 {
   pub skip_count: usize,
-  // TODO: body: Vec<Action> ?
 }
 
 // Action code 0x89
@@ -199,6 +186,5 @@ pub struct StrictMode {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct With {
-  #[serde(serialize_with = "buffer_to_hex", deserialize_with = "hex_to_buffer")]
-  pub with: Vec<u8>,
+  pub with_size: u16,
 }

--- a/tests/raw/define-function.json
+++ b/tests/raw/define-function.json
@@ -2,5 +2,5 @@
   "action": "define-function",
   "name": "f",
   "parameters": [],
-  "body": "26"
+  "body_size": 1
 }

--- a/ts/src/lib/actions/define-function.ts
+++ b/ts/src/lib/actions/define-function.ts
@@ -1,9 +1,10 @@
-import { $Bytes } from "kryo/builtins/bytes";
+import { $Uint16 } from "kryo/builtins/uint16";
 import { CaseStyle } from "kryo/case-style";
 import { ArrayType } from "kryo/types/array";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { LiteralType } from "kryo/types/literal";
 import { Ucs2StringType } from "kryo/types/ucs2-string";
+import { Uint16 } from "semantic-types";
 import { ActionBase } from "../action-base";
 import { $ActionType, ActionType } from "../action-type";
 
@@ -11,7 +12,7 @@ export interface DefineFunction extends ActionBase {
   action: ActionType.DefineFunction;
   name: string;
   parameters: string[];
-  body: Uint8Array;
+  bodySize: Uint16;
 }
 
 export const $DefineFunction: DocumentIoType<DefineFunction> = new DocumentType<DefineFunction>(() => ({
@@ -24,7 +25,7 @@ export const $DefineFunction: DocumentIoType<DefineFunction> = new DocumentType<
         maxLength: Infinity,
       }),
     },
-    body: {type: $Bytes},
+    bodySize: {type: $Uint16},
   },
   changeCase: CaseStyle.SnakeCase,
 }));

--- a/ts/src/lib/actions/define-function2.ts
+++ b/ts/src/lib/actions/define-function2.ts
@@ -1,12 +1,12 @@
 import { $Boolean } from "kryo/builtins/boolean";
-import { $Bytes } from "kryo/builtins/bytes";
+import { $Uint16 } from "kryo/builtins/uint16";
 import { CaseStyle } from "kryo/case-style";
 import { ArrayType } from "kryo/types/array";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { IntegerType } from "kryo/types/integer";
 import { LiteralType } from "kryo/types/literal";
 import { Ucs2StringType } from "kryo/types/ucs2-string";
-import { UintSize } from "semantic-types";
+import { Uint16, UintSize } from "semantic-types";
 import { ActionBase } from "../action-base";
 import { $ActionType, ActionType } from "../action-type";
 import { $Parameter, Parameter } from "../parameter";
@@ -25,7 +25,7 @@ export interface DefineFunction2 extends ActionBase {
   preloadGlobal: boolean;
   registerCount: UintSize;
   parameters: Parameter[];
-  body: Uint8Array;
+  bodySize: Uint16;
 }
 
 export const $DefineFunction2: DocumentIoType<DefineFunction2> = new DocumentType<DefineFunction2>(() => ({
@@ -48,7 +48,7 @@ export const $DefineFunction2: DocumentIoType<DefineFunction2> = new DocumentTyp
     preloadGlobal: {type: $Boolean},
     registerCount: {type: new IntegerType()},
     parameters: {type: new ArrayType({itemType: $Parameter, maxLength: Infinity})},
-    body: {type: $Bytes},
+    bodySize: {type: $Uint16},
   },
   changeCase: CaseStyle.SnakeCase,
 }));

--- a/ts/src/lib/actions/strict-mode.ts
+++ b/ts/src/lib/actions/strict-mode.ts
@@ -1,10 +1,10 @@
+import { $Uint8 } from "kryo/builtins/uint8";
 import { CaseStyle } from "kryo/case-style";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { LiteralType } from "kryo/types/literal";
+import { Uint8 } from "semantic-types";
 import { ActionBase } from "../action-base";
 import { $ActionType, ActionType } from "../action-type";
-import { Uint8 } from "semantic-types";
-import { $Uint8 } from "kryo/builtins/uint8";
 
 export interface StrictMode extends ActionBase {
   action: ActionType.StrictMode;

--- a/ts/src/lib/actions/try.ts
+++ b/ts/src/lib/actions/try.ts
@@ -1,26 +1,27 @@
-import { $Bytes } from "kryo/builtins/bytes";
+import { $Uint16 } from "kryo/builtins/uint16";
 import { CaseStyle } from "kryo/case-style";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { LiteralType } from "kryo/types/literal";
+import { Uint16 } from "semantic-types";
 import { ActionBase } from "../action-base";
 import { $ActionType, ActionType } from "../action-type";
 import { $CatchTarget, CatchTarget } from "../catch-target";
 
 export interface Try extends ActionBase {
   action: ActionType.Try;
-  try: Uint8Array;
-  catch?: Uint8Array;
+  trySize: Uint16;
+  catchSize?: Uint16;
   catchTarget: CatchTarget;
-  finally?: Uint8Array;
+  finallySize?: Uint16;
 }
 
 export const $Try: DocumentIoType<Try> = new DocumentType<Try>(() => ({
   properties: {
     action: {type: new LiteralType({type: $ActionType, value: ActionType.Try as ActionType.Try})},
-    try: {type: $Bytes},
-    catch: {type: $Bytes, optional: true},
+    trySize: {type: $Uint16},
+    catchSize: {type: $Uint16, optional: true},
     catchTarget: {type: $CatchTarget},
-    finally: {type: $Bytes, optional: true},
+    finallySize: {type: $Uint16, optional: true},
   },
   changeCase: CaseStyle.SnakeCase,
 }));

--- a/ts/src/lib/actions/with.ts
+++ b/ts/src/lib/actions/with.ts
@@ -1,19 +1,20 @@
-import { $Bytes } from "kryo/builtins/bytes";
+import { $Uint16 } from "kryo/builtins/uint16";
 import { CaseStyle } from "kryo/case-style";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { LiteralType } from "kryo/types/literal";
+import { Uint16 } from "semantic-types";
 import { ActionBase } from "../action-base";
 import { $ActionType, ActionType } from "../action-type";
 
 export interface With extends ActionBase {
   action: ActionType.With;
-  with: Uint8Array;
+  withSize: Uint16;
 }
 
 export const $With: DocumentIoType<With> = new DocumentType<With>(() => ({
   properties: {
     action: {type: new LiteralType({type: $ActionType, value: ActionType.With as ActionType.With})},
-    with: {type: $Bytes},
+    withSize: {type: $Uint16},
   },
   changeCase: CaseStyle.SnakeCase,
 }));

--- a/ts/src/lib/cfg-blocks/cfg-end-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-end-block.ts
@@ -1,10 +1,10 @@
 import { CaseStyle } from "kryo/case-style";
 import { ArrayType } from "kryo/types/array";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
-import { $CfgAction, CfgAction } from "../cfg-action";
-import { $CfgLabel, CfgLabel } from "../cfg-label";
-import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { LiteralType } from "kryo/types/literal";
+import { $CfgAction, CfgAction } from "../cfg-action";
+import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
+import { $CfgLabel, CfgLabel } from "../cfg-label";
 
 export interface CfgEndBlock {
   readonly type: CfgBlockType.End;

--- a/ts/src/lib/cfg-blocks/cfg-return-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-return-block.ts
@@ -1,10 +1,10 @@
 import { CaseStyle } from "kryo/case-style";
 import { ArrayType } from "kryo/types/array";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
-import { $CfgAction, CfgAction } from "../cfg-action";
-import { $CfgLabel, CfgLabel } from "../cfg-label";
-import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { LiteralType } from "kryo/types/literal";
+import { $CfgAction, CfgAction } from "../cfg-action";
+import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
+import { $CfgLabel, CfgLabel } from "../cfg-label";
 
 export interface CfgReturnBlock {
   readonly type: CfgBlockType.Return;

--- a/ts/src/lib/cfg-blocks/cfg-simple-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-simple-block.ts
@@ -1,10 +1,10 @@
 import { CaseStyle } from "kryo/case-style";
 import { ArrayType } from "kryo/types/array";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
-import { $CfgAction, CfgAction } from "../cfg-action";
-import { $CfgLabel, CfgLabel } from "../cfg-label";
-import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { LiteralType } from "kryo/types/literal";
+import { $CfgAction, CfgAction } from "../cfg-action";
+import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
+import { $CfgLabel, CfgLabel } from "../cfg-label";
 
 export interface CfgSimpleBlock {
   readonly type: CfgBlockType.Simple;

--- a/ts/src/lib/cfg-blocks/cfg-throw-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-throw-block.ts
@@ -1,10 +1,10 @@
 import { CaseStyle } from "kryo/case-style";
 import { ArrayType } from "kryo/types/array";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
-import { $CfgAction, CfgAction } from "../cfg-action";
-import { $CfgLabel, CfgLabel } from "../cfg-label";
-import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { LiteralType } from "kryo/types/literal";
+import { $CfgAction, CfgAction } from "../cfg-action";
+import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
+import { $CfgLabel, CfgLabel } from "../cfg-label";
 
 export interface CfgThrowBlock {
   readonly type: CfgBlockType.Throw;

--- a/ts/src/test/avm1.spec.ts
+++ b/ts/src/test/avm1.spec.ts
@@ -1,11 +1,11 @@
 import chai from "chai";
 import fs from "fs";
 import { JsonReader } from "kryo/readers/json";
+import { JsonValueWriter } from "kryo/writers/json-value";
 import sysPath from "path";
+import { $Cfg, Cfg } from "../lib/cfg";
 import meta from "./meta.js";
 import { readTextFile } from "./utils";
-import { JsonValueWriter } from "kryo/writers/json-value";
-import { $Cfg, Cfg } from "../lib/cfg";
 
 const PROJECT_ROOT: string = sysPath.join(meta.dirname, "..", "..", "..");
 const REPO_ROOT: string = sysPath.join(PROJECT_ROOT, "..");


### PR DESCRIPTION
Replace code bytes with code sizes for raw actions defining code blocks (`DefineFunction`, `DefineFunction2`, `Try`, `With`).