### PR TITLE
[all] Add `Error` raw action to represent invalid actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- **[Breaking change]** Add `Error` raw action to represent invalid actions.
+
 # 0.8.0 (2019-09-24)
 
 - **[Breaking change]** Use CFG blocks instead of actions for `CfgIf`, `WaitForFrame` and `WaitForFrame2`.

--- a/rs/src/actions.rs
+++ b/rs/src/actions.rs
@@ -59,6 +59,24 @@ pub struct DefineFunction2 {
   pub body_size: u16,
 }
 
+pub mod error {
+  use ::serde::{Deserialize, Serialize};
+
+  #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+  #[serde(rename_all = "snake_case")]
+  pub struct InvalidActionError {
+    pub message: String,
+  }
+}
+
+// No corresponding action code
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct Error {
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub error: Option<error::InvalidActionError>,
+}
+
 // Action code 0x83
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -13,6 +13,7 @@ mod value;
 #[serde(tag = "action", rename_all = "kebab-case")]
 pub enum Action {
   Unknown(actions::UnknownAction),
+  Error(actions::Error),
   Add,
   And,
   CastOp,
@@ -306,9 +307,11 @@ pub enum CfgAction {
 
 #[cfg(test)]
 mod tests {
-  use crate::Cfg;
-  use ::test_generator::test_resources;
   use std::path::Path;
+
+  use ::test_generator::test_resources;
+
+  use crate::Cfg;
 
   #[test_resources("../tests/avm1/[!.]*/*/")]
   fn test_cfg(path: &str) {
@@ -340,8 +343,9 @@ mod tests {
 
 #[cfg(test)]
 mod e2e_raw_tests {
-  use super::*;
   use ::test_generator::test_resources;
+
+  use super::*;
 
   #[test_resources("../tests/raw/*.json")]
   fn test_parse_action(path: &str) {

--- a/tests/raw/error-with-message.json
+++ b/tests/raw/error-with-message.json
@@ -1,0 +1,6 @@
+{
+  "action": "error",
+  "error": {
+    "message": "Invalid code for push value type: 0xff"
+  }
+}

--- a/tests/raw/error.json
+++ b/tests/raw/error.json
@@ -1,0 +1,3 @@
+{
+  "action": "error"
+}

--- a/ts/src/lib/action-type.ts
+++ b/ts/src/lib/action-type.ts
@@ -2,7 +2,8 @@ import { CaseStyle } from "kryo/case-style";
 import { TsEnumType } from "kryo/types/ts-enum";
 
 export enum ActionType {
-  Unknown = 0x00,
+  Unknown = 0x100,
+  Error = 0x101,
   Add = 0x0a,
   Add2 = 0x47,
   And = 0x10,

--- a/ts/src/lib/action.ts
+++ b/ts/src/lib/action.ts
@@ -3,6 +3,7 @@ import * as actions from "./actions/index";
 
 export type Action =
   actions.Unknown
+  | actions.Error
   | actions.Add
   | actions.Add2
   | actions.And
@@ -108,6 +109,7 @@ export type Action =
 export const $Action: TaggedUnionType<Action> = new TaggedUnionType<Action>(() => ({
   variants: [
     actions.$Unknown,
+    actions.$Error,
     actions.$Add,
     actions.$Add2,
     actions.$And,

--- a/ts/src/lib/actions/error.ts
+++ b/ts/src/lib/actions/error.ts
@@ -1,0 +1,19 @@
+import { CaseStyle } from "kryo/case-style";
+import { DocumentIoType, DocumentType } from "kryo/types/document";
+import { LiteralType } from "kryo/types/literal";
+import { ActionBase } from "../action-base";
+import { $ActionType, ActionType } from "../action-type";
+import { $InvalidActionError, InvalidActionError } from "../invalid-action-error";
+
+export interface Error extends ActionBase {
+  action: ActionType.Error;
+  error?: InvalidActionError;
+}
+
+export const $Error: DocumentIoType<Error> = new DocumentType<Error>({
+  properties: {
+    action: {type: new LiteralType({type: $ActionType, value: ActionType.Error})},
+    error: {type: $InvalidActionError, optional: true},
+  },
+  changeCase: CaseStyle.SnakeCase,
+});

--- a/ts/src/lib/actions/index.ts
+++ b/ts/src/lib/actions/index.ts
@@ -28,6 +28,7 @@ export { $Enumerate, Enumerate } from "./enumerate";
 export { $Enumerate2, Enumerate2 } from "./enumerate2";
 export { $Equals, Equals } from "./equals";
 export { $Equals2, Equals2 } from "./equals2";
+export { $Error, Error } from "./error";
 export { $Extends, Extends } from "./extends";
 export { $FsCommand2, FsCommand2 } from "./fs-command2";
 export { $GetMember, GetMember } from "./get-member";

--- a/ts/src/lib/invalid-action-error.ts
+++ b/ts/src/lib/invalid-action-error.ts
@@ -1,0 +1,14 @@
+import { CaseStyle } from "kryo/case-style";
+import { DocumentIoType, DocumentType } from "kryo/types/document";
+import { Ucs2StringType } from "kryo/types/ucs2-string";
+
+export interface InvalidActionError {
+  message: string;
+}
+
+export const $InvalidActionError: DocumentIoType<InvalidActionError> = new DocumentType<InvalidActionError>({
+  properties: {
+    message: {type: new Ucs2StringType({maxLength: Infinity})},
+  },
+  changeCase: CaseStyle.SnakeCase,
+});

--- a/ts/src/test/raw.spec.ts
+++ b/ts/src/test/raw.spec.ts
@@ -13,6 +13,8 @@ const JSON_READER: JsonReader = new JsonReader();
 const sampleNames: ReadonlyArray<string> = [
   "define-function",
   "trace",
+  "error",
+  "error-with-message",
 ];
 
 describe("$Action.read", function () {


### PR DESCRIPTION
This commit adds a new _virtual_ raw action (like `Unknown`) to allow the representation of invalid actions. Unlike `Unknown` where the parsers and emitters do not attempt to understand the action, `Error` indicates that the action is _known_ to be invalid and would trigger a "corrupted data" error in Adobe's Flash Player. The optional `error` field can provide additional information.