### PR TITLE
[ts] Add `data` to `Unknown` raw action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - **[Breaking change]** Add `Error` raw action to represent invalid actions.
 - **[Breaking]** Add required `Cfg.main` block to ensure the CFG is non-empty.
 
+## Typescript
+
+- **[Fix]** Add `data` field to `Unknown` raw actions.
+
 # 0.8.0 (2019-09-24)
 
 - **[Breaking change]** Use CFG blocks instead of actions for `CfgIf`, `WaitForFrame` and `WaitForFrame2`.

--- a/tests/raw/unknown-with-data.json
+++ b/tests/raw/unknown-with-data.json
@@ -1,0 +1,5 @@
+{
+  "action": "unknown",
+  "code": 128,
+  "data": "ff"
+}

--- a/tests/raw/unknown.json
+++ b/tests/raw/unknown.json
@@ -1,0 +1,5 @@
+{
+  "action": "unknown",
+  "code": 1,
+  "data": ""
+}

--- a/ts/src/lib/actions/unknown.ts
+++ b/ts/src/lib/actions/unknown.ts
@@ -1,3 +1,4 @@
+import { $Bytes } from "kryo/builtins/bytes";
 import { CaseStyle } from "kryo/case-style";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { IntegerType } from "kryo/types/integer";
@@ -9,12 +10,14 @@ import { $ActionType, ActionType } from "../action-type";
 export interface Unknown extends ActionBase {
   action: ActionType.Unknown;
   code: Uint8;
+  data: Uint8Array;
 }
 
 export const $Unknown: DocumentIoType<Unknown> = new DocumentType<Unknown>({
   properties: {
     action: {type: new LiteralType({type: $ActionType, value: ActionType.Unknown as ActionType.Unknown})},
     code: {type: new IntegerType()},
+    data: {type: $Bytes},
   },
   changeCase: CaseStyle.SnakeCase,
 });

--- a/ts/src/test/raw.spec.ts
+++ b/ts/src/test/raw.spec.ts
@@ -12,10 +12,12 @@ const JSON_READER: JsonReader = new JsonReader();
 
 const sampleNames: ReadonlyArray<string> = [
   "define-function",
-  "trace",
   "end",
   "error",
   "error-with-message",
+  "trace",
+  "unknown",
+  "unknown-with-data",
 ];
 
 describe("$Action.read", function () {


### PR DESCRIPTION
This commit fixes the Typescript declaration of `Unknown` to include a `data` field. This field is intended to hold the extra data associated to long-form actions. It enables to re-emit the action as-is without any information loss.

- Closes open-flash/avm1-tree#15