### PR TITLE
[ts] Exclude `End` and `Error` from `CfgAction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Next
 
 - **[Breaking change]** Add `Error` raw action to represent invalid actions.
-- **[Breaking]** Add required `Cfg.main` block to ensure the CFG is non-empty.
+- **[Breaking change]** Add `End` raw action.
 
 ## Typescript
 

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -204,9 +204,9 @@ pub enum CfgBlock {
   With(cfg_blocks::CfgWithBlock),
 }
 
-/// Similar to `Action` but no `Jump`, `If` `Throw`, `Return`, `Try`,
-/// `WaitForFrame`, `WaitForFrame2` and `With`, also different `DefineFunction`
-/// and `DefineFunction2`.
+/// Similar to `Action` but no `End`, `Error , `Jump`, `If` `Throw`, `Return`,
+/// `Try`, `WaitForFrame`, `WaitForFrame2` and `With`, also different
+/// `DefineFunction` and `DefineFunction2`.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(tag = "action", rename_all = "kebab-case")]
 pub enum CfgAction {

--- a/ts/src/lib/cfg-action.ts
+++ b/ts/src/lib/cfg-action.ts
@@ -5,6 +5,8 @@ import { $Action as $RawAction, Action as RawAction } from "./action";
 import { ActionType } from "./action-type";
 import { DefineFunction as RawDefineFunction } from "./actions/define-function";
 import { DefineFunction2 as RawDefineFunction2 } from "./actions/define-function2";
+import { End as RawEnd } from "./actions/end";
+import { Error as RawError } from "./actions/error";
 import { If as RawIf } from "./actions/if";
 import { Jump as RawJump } from "./actions/jump";
 import { Try as RawTry } from "./actions/try";
@@ -15,10 +17,17 @@ import { $CfgDefineFunction, CfgDefineFunction } from "./cfg-actions/cfg-define-
 import { $CfgDefineFunction2, CfgDefineFunction2 } from "./cfg-actions/cfg-define-function2";
 
 export type CfgAction =
-  Exclude<
-    RawAction,
-    RawDefineFunction | RawDefineFunction2 | RawIf | RawJump | RawTry | RawWaitForFrame | RawWaitForFrame2 | RawWith
-  >
+  Exclude<RawAction,
+    RawDefineFunction
+    | RawDefineFunction2
+    | RawEnd
+    | RawError
+    | RawIf
+    | RawJump
+    | RawTry
+    | RawWaitForFrame
+    | RawWaitForFrame2
+    | RawWith>
   | CfgDefineFunction
   | CfgDefineFunction2;
 
@@ -33,6 +42,8 @@ export const $CfgAction: TaggedUnionType<CfgAction> = new TaggedUnionType<CfgAct
       case ActionType.DefineFunction2:
         variants.push($CfgDefineFunction2);
         break;
+      case ActionType.End:
+      case ActionType.Error:
       case ActionType.Jump:
       case ActionType.Return:
       case ActionType.Try:


### PR DESCRIPTION
This commit fixes the Typescript declaration of `CfgAction`. Recent commits added 2 new raw actions: `End` and `Error`. These were accidentally added to the allowed variants of `CfgAction` while there already are dedicated CFG blocks.