### PR TITLE
[all] Add error information to `CfgErrorBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **[Breaking change]** Add `Error` raw action to represent invalid actions.
 - **[Breaking change]** Add `End` raw action.
+- **[Feature]** Add error information to `CfgErrorBlock`.
 
 ## Typescript
 

--- a/rs/src/actions.rs
+++ b/rs/src/actions.rs
@@ -59,22 +59,12 @@ pub struct DefineFunction2 {
   pub body_size: u16,
 }
 
-pub mod error {
-  use ::serde::{Deserialize, Serialize};
-
-  #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
-  #[serde(rename_all = "snake_case")]
-  pub struct InvalidActionError {
-    pub message: String,
-  }
-}
-
 // No corresponding action code
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct Error {
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub error: Option<error::InvalidActionError>,
+  pub error: Option<crate::InvalidActionError>,
 }
 
 // Action code 0x83

--- a/rs/src/cfg_blocks.rs
+++ b/rs/src/cfg_blocks.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 pub struct CfgErrorBlock {
   pub label: CfgLabel,
   pub actions: Vec<CfgAction>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub error: Option<crate::InvalidActionError>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -10,6 +10,12 @@ mod helpers;
 mod value;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct InvalidActionError {
+  pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(tag = "action", rename_all = "kebab-case")]
 pub enum Action {
   Unknown(actions::UnknownAction),

--- a/ts/src/lib/cfg-blocks/cfg-error-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-error-block.ts
@@ -5,11 +5,13 @@ import { LiteralType } from "kryo/types/literal";
 import { $CfgAction, CfgAction } from "../cfg-action";
 import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { $CfgLabel, CfgLabel } from "../cfg-label";
+import { $InvalidActionError, InvalidActionError } from "../invalid-action-error";
 
 export interface CfgErrorBlock {
   readonly type: CfgBlockType.Error;
   readonly label: CfgLabel;
   readonly actions: ReadonlyArray<CfgAction>;
+  readonly error?: InvalidActionError;
 }
 
 export const $CfgErrorBlock: DocumentIoType<CfgErrorBlock> = new DocumentType<CfgErrorBlock>(() => ({
@@ -17,6 +19,7 @@ export const $CfgErrorBlock: DocumentIoType<CfgErrorBlock> = new DocumentType<Cf
     type: {type: new LiteralType({type: $CfgBlockType, value: CfgBlockType.Error as CfgBlockType.Error})},
     label: {type: $CfgLabel},
     actions: {type: new ArrayType({itemType: $CfgAction, maxLength: Infinity})},
+    error: {type: $InvalidActionError, optional: true},
   },
   changeCase: CaseStyle.SnakeCase,
 }));


### PR DESCRIPTION
This commit updates the `CfgErrorBlock` type to surface information from the `Error` raw action. It is now possible to add an optional `error` field with a message.