### PR TITLE
[ts] Remove `readonly` modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Typescript
 
 - **[Fix]** Add `data` field to `Unknown` raw actions.
+- **[Fix]** Remove `readonly` modifier.
 
 # 0.8.0 (2019-09-24)
 

--- a/ts/src/lib/cfg-blocks/cfg-error-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-error-block.ts
@@ -8,10 +8,10 @@ import { $CfgLabel, CfgLabel } from "../cfg-label";
 import { $InvalidActionError, InvalidActionError } from "../invalid-action-error";
 
 export interface CfgErrorBlock {
-  readonly type: CfgBlockType.Error;
-  readonly label: CfgLabel;
-  readonly actions: ReadonlyArray<CfgAction>;
-  readonly error?: InvalidActionError;
+  type: CfgBlockType.Error;
+  label: CfgLabel;
+  actions: CfgAction[];
+  error?: InvalidActionError;
 }
 
 export const $CfgErrorBlock: DocumentIoType<CfgErrorBlock> = new DocumentType<CfgErrorBlock>(() => ({

--- a/ts/src/lib/cfg-blocks/cfg-if-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-if-block.ts
@@ -7,11 +7,11 @@ import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { $CfgLabel, $NullableCfgLabel, CfgLabel, NullableCfgLabel } from "../cfg-label";
 
 export interface CfgIfBlock {
-  readonly type: CfgBlockType.If;
-  readonly label: CfgLabel;
-  readonly actions: ReadonlyArray<CfgAction>;
-  readonly ifTrue: NullableCfgLabel;
-  readonly ifFalse: NullableCfgLabel;
+  type: CfgBlockType.If;
+  label: CfgLabel;
+  actions: CfgAction[];
+  ifTrue: NullableCfgLabel;
+  ifFalse: NullableCfgLabel;
 }
 
 export const $CfgIfBlock: DocumentIoType<CfgIfBlock> = new DocumentType<CfgIfBlock>(() => ({

--- a/ts/src/lib/cfg-blocks/cfg-return-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-return-block.ts
@@ -7,9 +7,9 @@ import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { $CfgLabel, CfgLabel } from "../cfg-label";
 
 export interface CfgReturnBlock {
-  readonly type: CfgBlockType.Return;
-  readonly label: CfgLabel;
-  readonly actions: ReadonlyArray<CfgAction>;
+  type: CfgBlockType.Return;
+  label: CfgLabel;
+  actions: CfgAction[];
 }
 
 export const $CfgReturnBlock: DocumentIoType<CfgReturnBlock> = new DocumentType<CfgReturnBlock>(() => ({

--- a/ts/src/lib/cfg-blocks/cfg-simple-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-simple-block.ts
@@ -7,10 +7,10 @@ import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { $CfgLabel, $NullableCfgLabel, CfgLabel, NullableCfgLabel } from "../cfg-label";
 
 export interface CfgSimpleBlock {
-  readonly type: CfgBlockType.Simple;
-  readonly label: CfgLabel;
-  readonly actions: ReadonlyArray<CfgAction>;
-  readonly next: NullableCfgLabel;
+  type: CfgBlockType.Simple;
+  label: CfgLabel;
+  actions: CfgAction[];
+  next: NullableCfgLabel;
 }
 
 export const $CfgSimpleBlock: DocumentIoType<CfgSimpleBlock> = new DocumentType<CfgSimpleBlock>(() => ({

--- a/ts/src/lib/cfg-blocks/cfg-throw-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-throw-block.ts
@@ -7,9 +7,9 @@ import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { $CfgLabel, CfgLabel } from "../cfg-label";
 
 export interface CfgThrowBlock {
-  readonly type: CfgBlockType.Throw;
-  readonly label: CfgLabel;
-  readonly actions: ReadonlyArray<CfgAction>;
+  type: CfgBlockType.Throw;
+  label: CfgLabel;
+  actions: CfgAction[];
 }
 
 export const $CfgThrowBlock: DocumentIoType<CfgThrowBlock> = new DocumentType<CfgThrowBlock>(() => ({

--- a/ts/src/lib/cfg-blocks/cfg-try-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-try-block.ts
@@ -11,7 +11,7 @@ import { $CfgLabel, CfgLabel } from "../cfg-label";
 export interface CfgTryBlock {
   type: CfgBlockType.Try;
   label: CfgLabel;
-  actions: ReadonlyArray<CfgAction>;
+  actions: CfgAction[];
   try: Cfg;
   catch?: Cfg;
   catchTarget: CatchTarget;

--- a/ts/src/lib/cfg-blocks/cfg-wait-for-frame-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-wait-for-frame-block.ts
@@ -9,12 +9,12 @@ import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { $CfgLabel, $NullableCfgLabel, CfgLabel, NullableCfgLabel } from "../cfg-label";
 
 export interface CfgWaitForFrameBlock {
-  readonly type: CfgBlockType.WaitForFrame;
-  readonly label: CfgLabel;
-  readonly actions: ReadonlyArray<CfgAction>;
-  readonly frame: UintSize;
-  readonly ifLoaded: NullableCfgLabel;
-  readonly ifNotLoaded: NullableCfgLabel;
+  type: CfgBlockType.WaitForFrame;
+  label: CfgLabel;
+  actions: CfgAction[];
+  frame: UintSize;
+  ifLoaded: NullableCfgLabel;
+  ifNotLoaded: NullableCfgLabel;
 }
 
 // tslint:disable-next-line:max-line-length

--- a/ts/src/lib/cfg-blocks/cfg-wait-for-frame2-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-wait-for-frame2-block.ts
@@ -7,11 +7,11 @@ import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { $CfgLabel, $NullableCfgLabel, CfgLabel, NullableCfgLabel } from "../cfg-label";
 
 export interface CfgWaitForFrame2Block {
-  readonly type: CfgBlockType.WaitForFrame2;
-  readonly label: CfgLabel;
-  readonly actions: ReadonlyArray<CfgAction>;
-  readonly ifLoaded: NullableCfgLabel;
-  readonly ifNotLoaded: NullableCfgLabel;
+  type: CfgBlockType.WaitForFrame2;
+  label: CfgLabel;
+  actions: CfgAction[];
+  ifLoaded: NullableCfgLabel;
+  ifNotLoaded: NullableCfgLabel;
 }
 
 // tslint:disable-next-line:max-line-length

--- a/ts/src/lib/cfg-blocks/cfg-with-block.ts
+++ b/ts/src/lib/cfg-blocks/cfg-with-block.ts
@@ -8,9 +8,9 @@ import { $CfgBlockType, CfgBlockType } from "../cfg-block-type";
 import { $CfgLabel, CfgLabel } from "../cfg-label";
 
 export interface CfgWithBlock {
-  readonly type: CfgBlockType.With;
-  readonly label: CfgLabel;
-  readonly actions: ReadonlyArray<CfgAction>;
+  type: CfgBlockType.With;
+  label: CfgLabel;
+  actions: CfgAction[];
   with: Cfg;
 }
 

--- a/ts/src/lib/cfg.ts
+++ b/ts/src/lib/cfg.ts
@@ -4,7 +4,7 @@ import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { $CfgBlock, CfgBlock } from "./cfg-block";
 
 export interface Cfg {
-  readonly blocks: ReadonlyArray<CfgBlock>;
+  blocks: CfgBlock[];
 }
 
 export const $Cfg: DocumentIoType<Cfg> = new DocumentType<Cfg>(() => ({


### PR DESCRIPTION
This commit removes the `readonly` modifier. It was intended to prevent accidental mutation but resulted in much higher friction when applying transformations to the CFG. Support for read-only versions may be reintroduced eventually but it should not prevent the mutable version from being used.