### PR TITLE
[all] Ensure `Cfg` is non empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **[Breaking change]** Add `Error` raw action to represent invalid actions.
 - **[Breaking change]** Add `End` raw action.
+- **[Breaking change]** Update `Cfg` representation to ensure it is non-empty.
 - **[Feature]** Add error information to `CfgErrorBlock`.
 
 ## Typescript

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -186,10 +186,12 @@ pub enum Action {
   // 0x9f
 }
 
+// TODO: Use a `NonEmptyVec` and custom serializer
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct Cfg {
-  pub blocks: Vec<CfgBlock>,
+  pub head: Box<CfgBlock>,
+  pub tail: Vec<CfgBlock>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -316,7 +318,7 @@ pub enum CfgAction {
 mod tests {
   use std::path::Path;
 
-  use ::test_generator::test_resources;
+  use test_generator::test_resources;
 
   use crate::Cfg;
 
@@ -350,7 +352,7 @@ mod tests {
 
 #[cfg(test)]
 mod e2e_raw_tests {
-  use ::test_generator::test_resources;
+  use test_generator::test_resources;
 
   use super::*;
 

--- a/ts/src/lib/cfg.ts
+++ b/ts/src/lib/cfg.ts
@@ -4,12 +4,14 @@ import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { $CfgBlock, CfgBlock } from "./cfg-block";
 
 export interface Cfg {
-  blocks: CfgBlock[];
+  head: CfgBlock;
+  tail: CfgBlock[];
 }
 
 export const $Cfg: DocumentIoType<Cfg> = new DocumentType<Cfg>(() => ({
   properties: {
-    blocks: {type: new ArrayType({itemType: $CfgBlock, maxLength: Infinity})},
+    head: {type: $CfgBlock},
+    tail: {type: new ArrayType({itemType: $CfgBlock, maxLength: Infinity})},
   },
   changeCase: CaseStyle.SnakeCase,
 }));


### PR DESCRIPTION
This commit refactors the `Cfg` type to force it to have at least one `CfgBlock`.
Empty control flow graphs proved to be ambiguous: they could either mean fall through to the next block or an end of the current context. This change allows to statically check that no such CFG exists and remove the ambiguity. It also provides a more convenient way to access the CFG entry point.

All the block are still logically part of the same group and you can jump between the `head` block and `tail` blocks. The `head`/`tail` names were chosen to hint at this logical connection, using conventional names from linked lists.