### PR TITLE
[all] Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.11.0 (2020-09-07)
 
 - **[Breaking change]** Use `PascalCase` for enums and types.
 

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "avm1-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15,7 +15,7 @@ dependencies = [
 name = "avm1-types-bin"
 version = "0.1.0"
 dependencies = [
- "avm1-types 0.10.0",
+ "avm1-types 0.11.0",
  "serde_json_v8 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm1-types"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Types for the Flash ActionScript Virtual Machine (AVM1)"
 documentation = "https://github.com/open-flash/avm1-types"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avm1-types",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Types for the Flash ActionScript Virtual Machine (AVM1)",
   "licenses": [
     {


### PR DESCRIPTION
- **[Breaking change]** Use `PascalCase` for enums and types.

## Rust

- **[Fix]** Update dependencies

## TypeScript

- **[Breaking change]** Update to native ESM.
- **[Fix]** Fix CFG `Action` type.
- **[Internal]** Switch from `tslint` to `eslint`.